### PR TITLE
Fixed not showing some channels for which I have permission

### DIFF
--- a/LocalModels/Permissions.cs
+++ b/LocalModels/Permissions.cs
@@ -119,13 +119,13 @@ namespace Discord_UWP.LocalModels
                     }
                     else if (overwrite.Type == "role" && LocalState.Guilds[guildId].members[userId].Roles.Contains(overwrite.Id))
                     {
-                        roleDenies = (GuildPermission)overwrite.Deny;
-                        roleAllows = (GuildPermission)overwrite.Allow;
+                        roleDenies |= (GuildPermission)overwrite.Deny;
+                        roleAllows |= (GuildPermission)overwrite.Allow;
                     }
                     else if (overwrite.Type == "member" && overwrite.Id == userId)
                     {
-                        memberDenies = (GuildPermission)overwrite.Deny;
-                        memberAllows = (GuildPermission)overwrite.Allow;
+                        memberDenies |= (GuildPermission)overwrite.Deny;
+                        memberAllows |= (GuildPermission)overwrite.Allow;
                     }
 
                 AddDenies(roleDenies);


### PR DESCRIPTION
I had problem with some channel, that was visible in original app, but not visible in Quarrel. What happened:

Channel has permission for two different roles, one role has access, but the other doesn't. In permission evaluation method the second role without permission came after the first one and has overwritten my allowed permission. Fix is simple - cumulate all permisions from all roles with bitwise "OR" operator.