### PR TITLE
Fixed "Share" button icon problem on Mobile

### DIFF
--- a/src/Quarrel/DataTemplates/Messages/MessageTemplate.xaml
+++ b/src/Quarrel/DataTemplates/Messages/MessageTemplate.xaml
@@ -124,7 +124,7 @@
                             <TextBlock Text="{x:Bind Footer.Text, Mode=OneWay}" FontSize="12" FontWeight="SemiBold" Opacity="0.4" VerticalAlignment="Center"/>
                         </StackPanel>
                         <Button Visibility="Collapsed" Style="{StaticResource IntegratedButton}" Grid.Column="1" HorizontalAlignment="Right">
-                            <SymbolIcon Symbol="Share"/>
+                            <FontIcon Glyph="&#xE72D;" FontFamily="Segoe MDL2 Assets" />
                         </Button>
                     </Grid>
                 </StackPanel>

--- a/src/Quarrel/SubPages/Settings/SettingsPage.xaml
+++ b/src/Quarrel/SubPages/Settings/SettingsPage.xaml
@@ -19,7 +19,11 @@
                 <ctl:NavigationViewItemHeader Content="User Settings"/>
                 <ctl:NavigationViewItem x:Name="MyAccountItem" Icon="ContactInfo" Content="My Account"/>
                 <ctl:NavigationViewItem x:Name="PrivacyItem" Icon="Permissions" Content="Privacy"/>
-                <ctl:NavigationViewItem IsEnabled="False" x:Name="ConnectionsItem" Icon="Share" Content="Connections"/>
+                <ctl:NavigationViewItem IsEnabled="False" x:Name="ConnectionsItem" Content="Connections">
+                    <ctl:NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xE72D;" FontFamily="Segoe MDL2 Assets" />
+                    </ctl:NavigationViewItem.Icon>
+                </ctl:NavigationViewItem>
 
                 <ctl:NavigationViewItemHeader Content="App Settings"/>
                 <ctl:NavigationViewItem x:Name="DisplayItem" Icon="View" Content="Display"/>


### PR DESCRIPTION
The Symbol.Share enum value does not exist on mobile, have to reference the Glyph on the font directly.