### PR TITLE
Added foundation for Chat Font Size setting

### DIFF
--- a/src/Quarrel.ViewModels/Services/Settings/SettingKeys.cs
+++ b/src/Quarrel.ViewModels/Services/Settings/SettingKeys.cs
@@ -14,6 +14,7 @@ namespace Quarrel.Services.Settings
         Bluple,
         ServerMuteIcons,
         ExpensiveRendering,
+        FontSize,
 
         // Behavior
         MentionGlow,

--- a/src/Quarrel.ViewModels/Settings/Pages/DisplaySettingsViewModel.cs
+++ b/src/Quarrel.ViewModels/Settings/Pages/DisplaySettingsViewModel.cs
@@ -103,5 +103,10 @@ namespace Quarrel.ViewModels.Settings.Pages
             get => SettingsService.Roaming.GetValue<bool>(SettingKeys.ExpensiveRendering);
             set => SettingsService.Roaming.SetValue(SettingKeys.ExpensiveRendering, value, notify: true);
         }
+        public int FontSize
+        {
+            get => SettingsService.Roaming.GetValue<int>(SettingKeys.FontSize);
+            set => SettingsService.Roaming.SetValue(SettingKeys.FontSize, value, notify: true);
+        }
     }
 }

--- a/src/Quarrel/Quarrel.csproj
+++ b/src/Quarrel/Quarrel.csproj
@@ -720,6 +720,9 @@
     <PackageReference Include="JetBrains.Annotations">
       <Version>2019.1.3</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Advertising.XAML">
+      <Version>10.1811.22001</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration">
       <Version>1.1.2</Version>
     </PackageReference>

--- a/src/Quarrel/Services/Settings/SettingsService.cs
+++ b/src/Quarrel/Services/Settings/SettingsService.cs
@@ -29,7 +29,6 @@ namespace Quarrel.Services.Settings
             Roaming.SetValue(SettingKeys.Bluple, false, false);
             Roaming.SetValue(SettingKeys.ServerMuteIcons, true, false);
             Roaming.SetValue(SettingKeys.ExpensiveRendering, true, false);
-            Roaming.SetValue(SettingKeys.FontSize, true, false);
 
             Roaming.SetValue(SettingKeys.MentionGlow, false, false);
             Roaming.SetValue(SettingKeys.ShowNoPermssions, false, false);

--- a/src/Quarrel/Services/Settings/SettingsService.cs
+++ b/src/Quarrel/Services/Settings/SettingsService.cs
@@ -29,6 +29,7 @@ namespace Quarrel.Services.Settings
             Roaming.SetValue(SettingKeys.Bluple, false, false);
             Roaming.SetValue(SettingKeys.ServerMuteIcons, true, false);
             Roaming.SetValue(SettingKeys.ExpensiveRendering, true, false);
+            Roaming.SetValue(SettingKeys.FontSize, true, false);
 
             Roaming.SetValue(SettingKeys.MentionGlow, false, false);
             Roaming.SetValue(SettingKeys.ShowNoPermssions, false, false);

--- a/src/Quarrel/SubPages/Settings/Pages/DisplaySettingsPage.xaml
+++ b/src/Quarrel/SubPages/Settings/Pages/DisplaySettingsPage.xaml
@@ -55,8 +55,8 @@
                 </StackPanel>
             </CheckBox>
 
-            <TextBlock Text="Chat Font Scaling" Margin="0,12,0,0"/>
-            <Slider Minimum="12" Maximum="24" Width="300" HorizontalAlignment="Left" Value="{x:Bind ViewModel.FontSize, Mode=TwoWay}"/>
+            <TextBlock Text="Chat Font Scaling" Margin="0,12,0,0" Opacity="0.5"/>
+            <Slider Minimum="12" Maximum="24" Width="300" HorizontalAlignment="Left" Value="{x:Bind ViewModel.FontSize, Mode=TwoWay}" IsEnabled="False"/>
         </StackPanel>
     </ScrollViewer>
 </Page>

--- a/src/Quarrel/SubPages/Settings/Pages/DisplaySettingsPage.xaml
+++ b/src/Quarrel/SubPages/Settings/Pages/DisplaySettingsPage.xaml
@@ -54,6 +54,9 @@
                     <TextBlock Text="Enable various expensive graphics such as Blur Effects and Audio Visualizers" FontSize="11" Opacity="0.5" TextWrapping="WrapWholeWords"/>
                 </StackPanel>
             </CheckBox>
+
+            <TextBlock Text="Chat Font Scaling" Margin="0,12,0,0"/>
+            <Slider Minimum="12" Maximum="24" Width="300" HorizontalAlignment="Left" Value="{x:Bind ViewModel.FontSize, Mode=TwoWay}"/>
         </StackPanel>
     </ScrollViewer>
 </Page>


### PR DESCRIPTION
The size setting loads and saves how it should, but I ran in to trouble binding the markdown control to it. I hope someone will be able to build off of what I started, in the meantime I disabled the slider in settings since its not finished.