### PR TITLE
Fixed blank line in some translations of "blocked" pivot

### DIFF
--- a/src/Quarrel/Localization/en/Controls.resw
+++ b/src/Quarrel/Localization/en/Controls.resw
@@ -138,8 +138,7 @@
     <comment>This is shown in the user flyout</comment>
   </data>
   <data name="BlockedTB.Text" xml:space="preserve">
-    <value>BLOCKED
-</value>
+    <value>BLOCKED</value>
     <comment>This is shown on the header of the friend panel pivot</comment>
   </data>
   <data name="ByTB.Text" xml:space="preserve">

--- a/src/Quarrel/Localization/es/Controls.resw
+++ b/src/Quarrel/Localization/es/Controls.resw
@@ -138,8 +138,7 @@
     <comment>This is shown in the user flyout</comment>
   </data>
   <data name="BlockedTB.Text" xml:space="preserve">
-    <value>BLOCKED
-</value>
+    <value>BLOCKED</value>
     <comment>This is shown on the header of the friend panel pivot</comment>
   </data>
   <data name="ByTB.Text" xml:space="preserve">

--- a/src/Quarrel/Localization/fr/Controls.resw
+++ b/src/Quarrel/Localization/fr/Controls.resw
@@ -138,8 +138,7 @@
     <comment>This is shown in the user flyout</comment>
   </data>
   <data name="BlockedTB.Text" xml:space="preserve">
-    <value>BLOCKED
-</value>
+    <value>BLOCKED</value>
     <comment>This is shown on the header of the friend panel pivot</comment>
   </data>
   <data name="ByTB.Text" xml:space="preserve">

--- a/src/Quarrel/Localization/it/Controls.resw
+++ b/src/Quarrel/Localization/it/Controls.resw
@@ -138,8 +138,7 @@
     <comment>This is shown in the user flyout</comment>
   </data>
   <data name="BlockedTB.Text" xml:space="preserve">
-    <value>BLOCKED
-</value>
+    <value>BLOCKED</value>
     <comment>This is shown on the header of the friend panel pivot</comment>
   </data>
   <data name="ByTB.Text" xml:space="preserve">

--- a/src/Quarrel/Localization/la/Controls.resw
+++ b/src/Quarrel/Localization/la/Controls.resw
@@ -138,8 +138,7 @@
     <comment>This is shown in the user flyout</comment>
   </data>
   <data name="BlockedTB.Text" xml:space="preserve">
-    <value>BLOCKED
-</value>
+    <value>BLOCKED</value>
     <comment>This is shown on the header of the friend panel pivot</comment>
   </data>
   <data name="ByTB.Text" xml:space="preserve">

--- a/src/Quarrel/Localization/no/Controls.resw
+++ b/src/Quarrel/Localization/no/Controls.resw
@@ -138,8 +138,7 @@
     <comment>This is shown in the user flyout</comment>
   </data>
   <data name="BlockedTB.Text" xml:space="preserve">
-    <value>BLOCKED
-</value>
+    <value>BLOCKED</value>
     <comment>This is shown on the header of the friend panel pivot</comment>
   </data>
   <data name="ByTB.Text" xml:space="preserve">

--- a/src/Quarrel/Localization/pt/Controls.resw
+++ b/src/Quarrel/Localization/pt/Controls.resw
@@ -138,8 +138,7 @@
     <comment>This is shown in the user flyout</comment>
   </data>
   <data name="BlockedTB.Text" xml:space="preserve">
-    <value>BLOCKED
-</value>
+    <value>BLOCKED</value>
     <comment>This is shown on the header of the friend panel pivot</comment>
   </data>
   <data name="ByTB.Text" xml:space="preserve">

--- a/src/Quarrel/Localization/ro/Controls.resw
+++ b/src/Quarrel/Localization/ro/Controls.resw
@@ -138,8 +138,7 @@
     <comment>This is shown in the user flyout</comment>
   </data>
   <data name="BlockedTB.Text" xml:space="preserve">
-    <value>BLOCKED
-</value>
+    <value>BLOCKED</value>
     <comment>This is shown on the header of the friend panel pivot</comment>
   </data>
   <data name="ByTB.Text" xml:space="preserve">


### PR DESCRIPTION
![Blocked](https://user-images.githubusercontent.com/18747724/85938374-e013d980-b8da-11ea-9637-d2bcdca4a10c.png)
There’s an extra new line at the end of BLOCKED in the friends control pivot for the English translation. This PR deletes it, fixing the BLOCKED text looking misaligned.