### PR TITLE
Support for previewing GIFV and improvements to their display

### DIFF
--- a/src/Quarrel.ViewModels/SubPages/AttachmentPageViewModel.cs
+++ b/src/Quarrel.ViewModels/SubPages/AttachmentPageViewModel.cs
@@ -34,5 +34,10 @@ namespace Quarrel.ViewModels.ViewModels.SubPages
         /// Gets the image as an Attachment (if available).
         /// </summary>
         public Attachment AsFile { get => Image as Attachment; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not the image is animated, such as a GIFV.
+        /// </summary>
+        public bool IsImageAnimated { get => Image.AnimatedImageUrl != null; }
     }
 }

--- a/src/Quarrel/DataTemplates/Messages/MessageTemplate.xaml
+++ b/src/Quarrel/DataTemplates/Messages/MessageTemplate.xaml
@@ -82,11 +82,13 @@
                                          InviteTemplate="{StaticResource InviteTemplate}"
                                              />
     <DataTemplate x:Key="GifvEmbedTemplate" x:DataType="embedbindables:BindableEmbed">
-        <MediaElement Source="{x:Bind Model.Video.Url}" IsLooping="True"
-                      Height="{x:Bind Model.Video.ActualHeight}" Width="{x:Bind Model.Video.ActualWidth}"
+        <!---Needs to make sure it does not get clipped horizontally-->
+        <MediaElement Source="{x:Bind Model.Video.ProxyUrl}" IsLooping="True"
+                      Height="{x:Bind Model.Video.ActualHeight}"
                       MaxHeight="250"
                       Tapped="Expand"
-                      HorizontalAlignment="Left" />
+                      HorizontalAlignment="Left"
+                      DataContext="{x:Bind}" />
     </DataTemplate>
     <DataTemplate x:Key="YoutubeEmbedTemplate" x:DataType="embedbindables:BindableEmbed">
         <embeds:YoutubeEmbedTemplate DataContext="{x:Bind Model}"

--- a/src/Quarrel/SubPages/AttachmentPage.xaml
+++ b/src/Quarrel/SubPages/AttachmentPage.xaml
@@ -10,7 +10,8 @@
     xmlns:tk="using:Microsoft.Toolkit.Uwp.UI.Controls"
     mc:Ignorable="d"
     d:DesignHeight="300"
-    d:DesignWidth="400">
+    d:DesignWidth="400"
+    Loaded="ControlLoaded">
 
     <UserControl.Resources>
         <messageconvert:SizeToHumanizedSizeConverter x:Key="SizeToHumanizedSizeConverter"/>
@@ -792,8 +793,10 @@
                             <Rectangle Fill="Transparent" Tapped="Rectangle_Tapped"/>
                             <Grid>
                                 <StackPanel x:Name="MultiPageStacker" MinWidth="240" MaxWidth="1000" Margin="68,76,68,48"/>
-                                <tk:ImageEx x:Name="ImageViewer" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                <tk:ImageEx x:Name="ImageViewer" x:Load="{x:Bind baseconvert:NotBoolToBoolConverter.Convert(ViewModel.IsImageAnimated)}" HorizontalAlignment="Center" VerticalAlignment="Center"
                                             Opacity="0" ImageExOpened="ImageOpened" Margin="24"/>
+                                <MediaElement x:Name="VideoViewer" x:Load="{x:Bind ViewModel.IsImageAnimated}" IsLooping="True" HorizontalAlignment="Center" VerticalAlignment="Center"
+                                              Opacity="0" CurrentStateChanged="VideoStateChanged" Margin="24"/>
                             </Grid>
                         </Grid>
                     </ScrollViewer>

--- a/src/_APIs/DiscordAPI/Interfaces/IPreviewableImage.cs
+++ b/src/_APIs/DiscordAPI/Interfaces/IPreviewableImage.cs
@@ -21,5 +21,10 @@ namespace DiscordAPI.Interfaces
         /// Gets the image's width.
         /// </summary>
         double ImageWidth { get; }
+
+        /// <summary>
+        /// Gets the URL to a video file or null if the image is static.
+        /// </summary>
+        string AnimatedImageUrl { get; }
     }
 }

--- a/src/_APIs/DiscordAPI/Models/Messages/Embeds/Attachment.cs
+++ b/src/_APIs/DiscordAPI/Models/Messages/Embeds/Attachment.cs
@@ -76,5 +76,9 @@ namespace DiscordAPI.Models.Messages.Embeds
         /// <inheritdoc/>
         [JsonIgnore]
         public double ImageWidth { get => ActualWidth; }
+
+        /// <inheritdoc/>
+        [JsonIgnore]
+        public string AnimatedImageUrl { get => null; }
     }
 }

--- a/src/_APIs/DiscordAPI/Models/Messages/Embeds/Embed.cs
+++ b/src/_APIs/DiscordAPI/Models/Messages/Embeds/Embed.cs
@@ -84,6 +84,19 @@ namespace DiscordAPI.Models.Messages.Embeds
                 return 0;
             }
         }
+
+        [JsonIgnore]
+        public string AnimatedImageUrl
+        {
+            get
+            {
+                if (Video != null)
+                {
+                    return Video.ProxyUrl;
+                }
+                return null;
+            }
+        }
     }
 
     public class EmbedThumbnail
@@ -120,6 +133,9 @@ namespace DiscordAPI.Models.Messages.Embeds
     {
         [JsonProperty("url")]
         public string Url { get; set; }
+
+        [JsonProperty("proxy_url")]
+        public string ProxyUrl { get; set; }
 
         [JsonProperty("height")]
         public int Height { get; set; }


### PR DESCRIPTION
- Fixes bug where Quarrel crashes if you click on a GIFV
- GIFVs now load from their proxy URL instead of directly (should investigate other areas where videos might be loading directly, but unrelated to this PR)
- Changed how GIFVs are shown in the chat—before they tried to use their original width even though their height was capped at 250. This gave a wide letterbox and cut them off
    - This PR does not prevent GIFVs from being cut off if the window is too narrow, but removes the letterboxing (experience is improved, but not perfect)
- Image previewer now has an minimal looping video player to show GIFVs
    - It uses `x:Load` to decide whether to show the image control or the video control
        - I moved some parts that were in the `AttachmentPage` constructor into the `Load` event because otherwise the control would be `null`
    - Save, open, and copy link buttons all refer to the video if the image is animated
        - Not done: clicking share sends a link instead of the video file itself (I couldn’t get StorageFile to share, but this is potentially preferable or good enough)