### PR TITLE
Fixes crash when proxy URL is not set for GIFV

### DIFF
--- a/src/Quarrel/DataTemplates/Messages/MessageTemplate.xaml
+++ b/src/Quarrel/DataTemplates/Messages/MessageTemplate.xaml
@@ -83,7 +83,7 @@
                                              />
     <DataTemplate x:Key="GifvEmbedTemplate" x:DataType="embedbindables:BindableEmbed">
         <!---Needs to make sure it does not get clipped horizontally-->
-        <MediaElement Source="{x:Bind Model.Video.ProxyUrl}" IsLooping="True"
+        <MediaElement Source="{x:Bind Model.Video.BindUrl}" IsLooping="True"
                       Height="{x:Bind Model.Video.ActualHeight}"
                       MaxHeight="250"
                       Tapped="Expand"

--- a/src/_APIs/DiscordAPI/Models/Messages/Embeds/Embed.cs
+++ b/src/_APIs/DiscordAPI/Models/Messages/Embeds/Embed.cs
@@ -92,7 +92,7 @@ namespace DiscordAPI.Models.Messages.Embeds
             {
                 if (Video != null)
                 {
-                    return Video.ProxyUrl;
+                    return Video.BindUrl;
                 }
                 return null;
             }
@@ -148,6 +148,9 @@ namespace DiscordAPI.Models.Messages.Embeds
 
         [JsonIgnore]
         public double ActualWidth { get => Width != 0 ? Width : double.NaN; }
+
+        [JsonIgnore]
+        public string BindUrl => ProxyUrl ?? Url;
     }
 
     public class EmbedProvider


### PR DESCRIPTION
`proxy_url` is sometimes `null`. This PR checks for that and uses the regular URL if there is no proxy URL provided. Previous behavior was crashing.