### PR TITLE
Correct translation keys in server dropdown

### DIFF
--- a/src/Quarrel/Controls/Channels/ChannelListHeader.xaml
+++ b/src/Quarrel/Controls/Channels/ChannelListHeader.xaml
@@ -17,12 +17,12 @@
         <!--Guild Flyout-->
         <Button.Flyout>
             <MenuFlyout Placement="Bottom" MenuFlyoutPresenterStyle="{StaticResource GuildButtonFlyoutStyle}">
-                <MenuFlyoutItem x:Uid="/Controls/AddChannelMFI" Icon="AddFriend" Text="Invite People" Style="{ThemeResource GuildButtonFlyoutItemStyle}" Foreground="{ThemeResource SystemAccentColor}" Visibility="{x:Bind ViewModel.Permissions.CreateInstantInvite, Mode=OneWay}"
+                <MenuFlyoutItem x:Uid="/Controls/InvitePeopleMFI" Icon="AddFriend" Text="Invite People" Style="{ThemeResource GuildButtonFlyoutItemStyle}" Foreground="{ThemeResource SystemAccentColor}" Visibility="{x:Bind ViewModel.Permissions.CreateInstantInvite, Mode=OneWay}"
                                 Command="{x:Bind ViewModel.CreateInvite, Mode=OneWay}"/>
                 <MenuFlyoutSeparator Visibility="{x:Bind ViewModel.Permissions.CreateInstantInvite, Mode=OneWay}" Width="224"/>
                 <MenuFlyoutItem x:Uid="/Controls/GuildSettingsMFI" Icon="Setting" Text="Settings" Style="{ThemeResource GuildButtonFlyoutItemStyle}" Command="{x:Bind ViewModel.OpenGuildSettings}"/>
                 <MenuFlyoutSeparator Visibility="{x:Bind ViewModel.Permissions.ManageChannels, Mode=OneWay}"/>
-                <MenuFlyoutItem x:Uid="/Controls/InvitePeopleMFI" Icon="Add" Text="Add Channel" Style="{ThemeResource GuildButtonFlyoutItemStyle}" Command="{x:Bind ViewModel.AddChannelCommand}" Visibility="{x:Bind ViewModel.Permissions.ManageChannels, Mode=OneWay}"/>
+                <MenuFlyoutItem x:Uid="/Controls/AddChannelMFI" Icon="Add" Text="Add Channel" Style="{ThemeResource GuildButtonFlyoutItemStyle}" Command="{x:Bind ViewModel.AddChannelCommand}" Visibility="{x:Bind ViewModel.Permissions.ManageChannels, Mode=OneWay}"/>
                 <MenuFlyoutSeparator Visibility="{x:Bind baseconvert:NotBoolToVisibilityConverter.Convert(ViewModel.IsOwner), Mode=OneWay}"/>
                 <MenuFlyoutItem x:Uid="/Controls/LeaveServerMFI" Icon="Clear" Text="Leave Server" Style="{ThemeResource GuildButtonFlyoutItemStyle}" Foreground="{ThemeResource dnd}" Visibility="{x:Bind baseconvert:NotBoolToVisibilityConverter.Convert(ViewModel.IsOwner), Mode=OneWay}"/>
             </MenuFlyout>


### PR DESCRIPTION
![Quarrel server dropdown with add channel and invite people labels swapped incorrectly](https://user-images.githubusercontent.com/18747724/128630742-392f8996-fa3c-46c2-94ae-166fbc1f42f3.png)

The translation keys were incorrectly swapped with each other, so the Invite People button is mislabeled as “Add Channel,” and the Add Channel button is mislabeled as “Invite People.”

Partly fixes #416.